### PR TITLE
Fix requirements.txt install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-eosio-signer@git+https://github.com/bullish-exchange/python-signer
+eosio-signer@git+https://github.com/bullish-exchange/python-signer@fix_version
 websocket-client==1.3.1
 requests==2.25.1
 python-dotenv==1.0.0


### PR DESCRIPTION
New versions of tooling don't allow for 'develop' as a version - this now points to a branch that has the proper version. We can revert this once https://github.com/bullish-exchange/python-signer/pull/2 is merged.